### PR TITLE
Add mutually exclusive parameter set support for custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A new type of shell.
 - [Learning About Nu](#learning-about-nu)
 - [Installation](#installation)
 - [Configuration](#configuration)
+- [Parameter sets](#parameter-sets)
 - [Philosophy](#philosophy)
   - [Pipelines](#pipelines)
   - [Opening files](#opening-files)
@@ -70,6 +71,34 @@ $nu.config-path
 ```
 
 Please see our [book](https://www.nushell.sh) for all of the Nushell documentation.
+
+
+## Parameter sets
+
+Custom commands can now describe mutually exclusive groups of arguments using *parameter sets*. A parameter set defines the arguments that belong together, and Nushell enforces that exactly one set is used each time the command runs. Within a set you can mark individual parameters as mandatory, while parameters that belong to multiple sets can be shared across the different call patterns.
+
+```nu
+def "git add-to-head" [
+  --staged(-s) @set(staged) @mandatory
+  ...rest: string @set(paths) @mandatory(paths)
+] {
+  if $staged {
+    print "Adding staged files"
+  } else {
+    print $"Adding ($rest | length) path(s)"
+  }
+}
+
+# Valid calls
+git add-to-head -s
+git add-to-head Cargo.toml README.md
+
+# Invalid combinations
+git add-to-head -s Cargo.toml  # arguments come from different sets
+git add-to-head                # no set selected
+```
+
+Use `@set(name)` to assign a parameter to a set and `@mandatory` (optionally with a set name) to require it when that set is chosen. Nushell surfaces clear parse-time errors when the call is ambiguous, mixes arguments from multiple sets, or omits mandatory members of the selected set.
 
 
 ## Philosophy

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -368,6 +368,18 @@ fn get_command_documentation(
         }
     }
 
+    let parameter_sets = sig.collect_parameter_sets();
+    if !parameter_sets.is_empty() {
+        let _ = write!(long_desc, "\n{help_section_name}Parameter sets{RESET}:\n");
+        let _ = writeln!(
+            long_desc,
+            "  Exactly one of the following sets may be used when calling this command."
+        );
+        for summary in parameter_sets.summaries() {
+            let _ = writeln!(long_desc, "  - {summary}");
+        }
+    }
+
     fn get_term_width() -> usize {
         if let Ok((w, _h)) = terminal_size() {
             w as usize

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -360,6 +360,8 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
                 var_id: Some(*var_id),
                 default_value: None,
                 completion: None,
+                parameter_sets: vec![],
+                parameter_set_mandatory: vec![],
             },
         );
     }

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -567,6 +567,55 @@ pub enum ParseError {
         help("try following this line with a `def` or `extern` definition")
     )]
     AttributeRequiresDefinition(#[label("must be followed by a definition")] Span),
+
+    #[error("Unknown parameter attribute '{attribute}'.")]
+    #[diagnostic(
+        code(nu::parser::parameter_attribute_unknown),
+        help("Supported attributes: @set(name), @mandatory, @mandatory(name).")
+    )]
+    UnknownParameterAttribute {
+        attribute: String,
+        #[label("unknown attribute")]
+        span: Span,
+    },
+
+    #[error("Invalid parameter attribute '{attribute}'.")]
+    #[diagnostic(code(nu::parser::parameter_attribute_invalid), help("{help}"))]
+    InvalidParameterAttribute {
+        attribute: String,
+        help: String,
+        #[label("invalid attribute")]
+        span: Span,
+    },
+
+    #[error("Arguments {arguments} come from different parameter sets.")]
+    #[diagnostic(code(nu::parser::parameter_set_conflict), help("{help}"))]
+    ParameterSetConflict {
+        arguments: String,
+        #[label("conflicting arguments")]
+        span: Span,
+        help: String,
+    },
+
+    #[error("{message}")]
+    #[diagnostic(code(nu::parser::parameter_set_missing), help("{help}"))]
+    ParameterSetMissing {
+        message: String,
+        #[label("{label}")]
+        span: Span,
+        label: String,
+        help: String,
+    },
+
+    #[error("Ambiguous parameter set selection.")]
+    #[diagnostic(code(nu::parser::parameter_set_ambiguous), help("{help}"))]
+    ParameterSetAmbiguous {
+        arguments: String,
+        candidates: Vec<String>,
+        #[label("ambiguous arguments")]
+        span: Span,
+        help: String,
+    },
 }
 
 impl ParseError {
@@ -659,6 +708,11 @@ impl ParseError {
             ParseError::AssignmentRequiresVar(s) => *s,
             ParseError::AssignmentRequiresMutableVar(s) => *s,
             ParseError::AttributeRequiresDefinition(s) => *s,
+            ParseError::UnknownParameterAttribute { span, .. } => *span,
+            ParseError::InvalidParameterAttribute { span, .. } => *span,
+            ParseError::ParameterSetConflict { span, .. } => *span,
+            ParseError::ParameterSetMissing { span, .. } => *span,
+            ParseError::ParameterSetAmbiguous { span, .. } => *span,
         }
     }
 }

--- a/crates/nu-protocol/tests/test_signature.rs
+++ b/crates/nu-protocol/tests/test_signature.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{Flag, PositionalArg, Signature, SyntaxShape};
+use nu_protocol::{Flag, ParameterSet, PositionalArg, Signature, SyntaxShape};
 
 #[test]
 fn test_signature() {
@@ -46,6 +46,8 @@ fn test_signature_chained() {
             var_id: None,
             default_value: None,
             completion: None,
+            parameter_sets: vec![],
+            parameter_set_mandatory: vec![],
         })
     );
     assert_eq!(
@@ -57,6 +59,8 @@ fn test_signature_chained() {
             var_id: None,
             default_value: None,
             completion: None,
+            parameter_sets: vec![],
+            parameter_set_mandatory: vec![],
         })
     );
     assert_eq!(
@@ -68,6 +72,8 @@ fn test_signature_chained() {
             var_id: None,
             default_value: None,
             completion: None,
+            parameter_sets: vec![],
+            parameter_set_mandatory: vec![],
         })
     );
 
@@ -82,6 +88,8 @@ fn test_signature_chained() {
             var_id: None,
             default_value: None,
             completion: None,
+            parameter_sets: vec![],
+            parameter_set_mandatory: vec![],
         })
     );
 
@@ -96,6 +104,8 @@ fn test_signature_chained() {
             var_id: None,
             default_value: None,
             completion: None,
+            parameter_sets: vec![],
+            parameter_set_mandatory: vec![],
         })
     );
 }
@@ -174,4 +184,31 @@ fn test_signature_round_trip() {
         .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
 
     assert_eq!(signature.rest_positional, returned.rest_positional,);
+}
+
+#[test]
+fn collect_parameter_sets_summaries() {
+    let mut signature = Signature::new("foo");
+
+    let mut staged_flag = Flag::new("staged").short('s').required();
+    staged_flag.parameter_sets = vec!["staged".to_string()];
+    staged_flag.parameter_set_mandatory = vec!["staged".to_string()];
+
+    let mut rest = PositionalArg::new("paths", SyntaxShape::String);
+    rest.parameter_sets = vec!["paths".to_string()];
+    rest.parameter_set_mandatory = vec!["paths".to_string()];
+
+    signature.named.push(staged_flag);
+    signature.rest_positional = Some(rest);
+    signature.parameter_sets = vec![ParameterSet::new("staged"), ParameterSet::new("paths")];
+
+    let metadata = signature.collect_parameter_sets();
+    assert_eq!(
+        metadata.set_names,
+        vec!["staged".to_string(), "paths".to_string()]
+    );
+
+    let summaries = metadata.summaries();
+    assert!(summaries.iter().any(|entry| entry.contains("staged")));
+    assert!(summaries.iter().any(|entry| entry.contains("paths")));
 }


### PR DESCRIPTION
## What / Why
* Introduce parameter set metadata on command signatures so Nushell can enforce mutually exclusive argument groups.
* Parse `@set(...)` and `@mandatory` attributes in custom command definitions and surface targeted parse errors when calls cross sets or omit mandatory members.

## Usage / Examples
```nu
def "git add-to-head" [
  --staged(-s) @set(staged) @mandatory
  ...rest: string @set(paths) @mandatory(paths)
] {
  if $staged {
    print "Adding staged files"
  } else {
    print $"Adding ($rest | length) path(s)"
  }
}

# valid
git add-to-head -s
git add-to-head Cargo.toml README.md

# invalid
git add-to-head -s Cargo.toml
```

## Compatibility / Risks
* Parameter sets are opt-in and signatures without the new attributes continue to parse and execute unchanged.
* `cargo test --workspace --all-features` still fails upstream because enabling both TLS backends trips the `compile_error!` guard.

## Implementation Notes
* Store per-argument parameter set metadata on `Flag`/`PositionalArg`, collect summaries from `Signature`, and render them in `help` output.
* Parse `@set`/`@mandatory` attributes in `parse_signature_helper` and apply them to the signature, with diagnostics for misuse.
* Validate calls in `check_call` to detect conflicts, missing mandatory members, or ambiguous selections, reporting the new `ParseError` variants.
* Document parameter sets in the README and add parser/protocol unit tests covering success, conflicts, ambiguity, and attribute errors.

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p nu-parser`
- `cargo test -p nu-protocol`
- `cargo test --workspace --all-features` *(fails: multiple TLS backends enabled)*

Closes #3947

------
https://chatgpt.com/codex/tasks/task_e_68ce919125888322a8053e9bbe27c17a